### PR TITLE
feat(config): add shared lefthook turborepo config

### DIFF
--- a/.changeset/lefthook-configs.md
+++ b/.changeset/lefthook-configs.md
@@ -1,0 +1,5 @@
+---
+"@vlandoss/config": minor
+---
+
+Add shared lefthook configs (`turborepo.yml`) consumable via lefthook remotes

--- a/.changeset/lefthook-configs.md
+++ b/.changeset/lefthook-configs.md
@@ -1,5 +1,0 @@
----
-"@vlandoss/config": minor
----
-
-Add shared lefthook configs (`turborepo.yml`) consumable via lefthook remotes

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,24 +1,2 @@
-pre-commit:
-  parallel: true
-  jobs:
-    - name: check
-      run: pnpm rr check --fix-staged
-      stage_fixed: true
-
-    - name: tsc
-      run: pnpm rr pkgs --files {staged_files} --decorator turbo | xargs pnpm test:types
-      glob:
-        - "*.{ts,tsx}"
-        - "tsconfig.json"
-
-pre-push:
-  jobs:
-    - name: test
-      run: |
-        branch="$(git branch --show-current)"
-
-        if [ "$branch" = "main" ]; then
-          pnpm test --filter='...[HEAD^]'
-        else
-          pnpm test --affected
-        fi
+extends:
+  - packages/config/src/lefthook/turborepo.yml

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -57,6 +57,3 @@ remotes:
 
 Then `pnpm lefthook install` to sync the hooks.
 
-Available presets:
-
-- `packages/config/src/lefthook/turborepo.yml` — `pre-commit` (Biome `jscheck`, `turbo test:types`) and `pre-push` (`turbo test --affected`). Assumes the consumer repo has `@vlandoss/run-run` and `turbo` available.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -41,3 +41,22 @@ Available TypeScript presets:
 - `@vlandoss/config/ts/dom/lib`
 - `@vlandoss/config/ts/no-dom/app`
 - `@vlandoss/config/ts/no-dom/lib`
+
+## Lefthook
+
+Consumed via [lefthook remotes](https://lefthook.dev/examples/remotes) — no `pnpm add` needed.
+
+`lefthook.yml`:
+
+```yaml
+remotes:
+  - git_url: https://github.com/variableland/dx
+    configs:
+      - packages/config/src/lefthook/turborepo.yml
+```
+
+Then `pnpm lefthook install` to sync the hooks.
+
+Available presets:
+
+- `packages/config/src/lefthook/turborepo.yml` — `pre-commit` (Biome `jscheck`, `turbo test:types`) and `pre-push` (`turbo test --affected`). Assumes the consumer repo has `@vlandoss/run-run` and `turbo` available.

--- a/packages/config/src/lefthook/turborepo.yml
+++ b/packages/config/src/lefthook/turborepo.yml
@@ -1,0 +1,24 @@
+pre-commit:
+  parallel: true
+  jobs:
+    - name: jscheck
+      run: pnpm rr jscheck --fix-staged
+      stage_fixed: true
+
+    - name: tscheck
+      run: turbo run test:types --filter='...[HEAD]'
+      glob:
+        - "*.{ts,tsx}"
+        - "tsconfig.json"
+
+pre-push:
+  jobs:
+    - name: test
+      run: |
+        branch="$(git branch --show-current)"
+
+        if [ "$branch" = "main" ]; then
+          turbo run test --filter='...[HEAD^]'
+        else
+          turbo run test --affected
+        fi


### PR DESCRIPTION
## Summary
- Add `packages/config/src/lefthook/turborepo.yml` so consumers can wire it via lefthook remotes (`https://lefthook.dev/examples/remotes`)
- Switch the root `lefthook.yml` to `extends` the shared file (dogfood without going through the remote round-trip)
- Changeset: minor bump for `@vlandoss/config`

## Test plan
- [x] `pnpm lefthook install` syncs `pre-commit` and `pre-push`
- [x] `pnpm lefthook dump` shows the merged `pre-commit` (`jscheck`, `tscheck`) and `pre-push` (`test`) jobs from the shared config
- [x] `pre-commit` ran on commit
- [x] `pre-push` ran on push (turbo `test` succeeded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)