### PR TITLE
refactor: use package imports field and @vlandoss/config tsconfigs

### DIFF
--- a/.changeset/package-imports-and-config-tsconfig.md
+++ b/.changeset/package-imports-and-config-tsconfig.md
@@ -1,0 +1,9 @@
+---
+"@vlandoss/clibuddy": patch
+"@vlandoss/localproxy": patch
+"@vlandoss/loggy": patch
+"@vlandoss/run-run": patch
+"@vlandoss/starter": patch
+---
+
+Switch tsconfigs to `@vlandoss/config/ts/*` and move path aliases from tsconfig `paths` to the `package.json` `imports` field (`#src/*`, `#test/*`). Relative imports now use explicit `.ts` extensions.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "@changesets/changelog-github": "0.5.2",
     "@changesets/cli": "2.29.8",
-    "@total-typescript/tsconfig": "1.0.4",
     "@types/bun": "latest",
     "@vlandoss/config": "workspace:*",
     "@vlandoss/run-run": "workspace:*",

--- a/packages/clibuddy/tsconfig.json
+++ b/packages/clibuddy/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["@total-typescript/tsconfig/bundler/no-dom/library-monorepo"]
+  "extends": ["@vlandoss/config/ts/no-dom/lib"]
 }

--- a/packages/localproxy/tsconfig.json
+++ b/packages/localproxy/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@total-typescript/tsconfig/bundler/no-dom/app"],
+  "extends": ["@vlandoss/config/ts/no-dom/app"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/packages/loggy/tsconfig.json
+++ b/packages/loggy/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["@total-typescript/tsconfig/bundler/no-dom/library-monorepo"]
+  "extends": ["@vlandoss/config/ts/no-dom/lib"]
 }

--- a/packages/run-run/package.json
+++ b/packages/run-run/package.json
@@ -13,6 +13,10 @@
   "license": "MIT",
   "author": "rcrd <rcrd@variable.land>",
   "type": "module",
+  "imports": {
+    "#src/*": "./src/*",
+    "#test/*": "./test/*"
+  },
   "exports": {
     "./config": {
       "bun": "./src/lib/config.ts",

--- a/packages/run-run/src/main.ts
+++ b/packages/run-run/src/main.ts
@@ -1,7 +1,7 @@
 import { run } from "@vlandoss/clibuddy";
-import { createProgram, type Options } from "./program";
-import { parseArgs } from "./program/parse-args";
-import { logger } from "./services/logger";
+import { createProgram, type Options } from "./program/index.ts";
+import { parseArgs } from "./program/parse-args.ts";
+import { logger } from "./services/logger.ts";
 
 export async function main(options: Options) {
   await run(async () => {

--- a/packages/run-run/src/program/__tests__/snapshots.test.ts
+++ b/packages/run-run/src/program/__tests__/snapshots.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
-import { createTestProgram, execCli, mocked } from "#test/helpers";
+import { createTestProgram, execCli, mocked } from "#test/helpers.ts";
 
 const { program, ctx } = await createTestProgram();
 const $ = ctx.shell.$;

--- a/packages/run-run/src/program/commands/build-lib.ts
+++ b/packages/run-run/src/program/commands/build-lib.ts
@@ -1,6 +1,6 @@
 import { createCommand } from "commander";
-import { TOOL_LABELS } from "#/program/ui";
-import type { Context } from "#/services/ctx";
+import { TOOL_LABELS } from "#src/program/ui.ts";
+import type { Context } from "#src/services/ctx.ts";
 
 export function createBuildLibCommand(ctx: Context) {
   return createCommand("build:lib")

--- a/packages/run-run/src/program/commands/clean.ts
+++ b/packages/run-run/src/program/commands/clean.ts
@@ -2,7 +2,7 @@ import { cwd } from "@vlandoss/clibuddy";
 import { createCommand } from "commander";
 import { type GlobOptions, glob } from "glob";
 import { rimraf } from "rimraf";
-import { logger } from "#/services/logger";
+import { logger } from "#src/services/logger.ts";
 import { TOOL_LABELS } from "../ui";
 
 type Options = {

--- a/packages/run-run/src/program/commands/config.ts
+++ b/packages/run-run/src/program/commands/config.ts
@@ -1,6 +1,6 @@
 import { palette } from "@vlandoss/clibuddy";
 import { createCommand } from "commander";
-import type { Context } from "#/services/ctx";
+import type { Context } from "#src/services/ctx.ts";
 
 export function createConfigCommand(ctx: Context) {
   return createCommand("config")

--- a/packages/run-run/src/program/commands/format.ts
+++ b/packages/run-run/src/program/commands/format.ts
@@ -1,8 +1,8 @@
 import { createCommand } from "commander";
-import { BiomeService } from "#/services/biome";
-import type { Context } from "#/services/ctx";
-import { OxfmtService } from "#/services/oxfmt";
-import type { Formatter } from "#/types/tool";
+import { BiomeService } from "#src/services/biome.ts";
+import type { Context } from "#src/services/ctx.ts";
+import { OxfmtService } from "#src/services/oxfmt.ts";
+import type { Formatter } from "#src/types/tool.ts";
 
 type ActionOptions = {
   fix?: boolean;

--- a/packages/run-run/src/program/commands/jscheck.ts
+++ b/packages/run-run/src/program/commands/jscheck.ts
@@ -1,7 +1,7 @@
 import { createCommand } from "commander";
-import { BiomeService } from "#/services/biome";
-import type { Context } from "#/services/ctx";
-import type { StaticChecker } from "#/types/tool";
+import { BiomeService } from "#src/services/biome.ts";
+import type { Context } from "#src/services/ctx.ts";
+import type { StaticChecker } from "#src/types/tool.ts";
 
 type ActionOptions = {
   fix?: boolean;

--- a/packages/run-run/src/program/commands/lint.ts
+++ b/packages/run-run/src/program/commands/lint.ts
@@ -1,8 +1,8 @@
 import { createCommand } from "commander";
-import { BiomeService } from "#/services/biome";
-import type { Context } from "#/services/ctx";
-import { OxlintService } from "#/services/oxlint";
-import type { Linter } from "#/types/tool";
+import { BiomeService } from "#src/services/biome.ts";
+import type { Context } from "#src/services/ctx.ts";
+import { OxlintService } from "#src/services/oxlint.ts";
+import type { Linter } from "#src/types/tool.ts";
 
 type ActionOptions = {
   check?: boolean;

--- a/packages/run-run/src/program/commands/pkgs.ts
+++ b/packages/run-run/src/program/commands/pkgs.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
 import { type Command, createCommand, Option } from "commander";
 import memoize from "memoize";
-import type { Context } from "#/services/ctx";
-import { logger } from "#/services/logger";
+import type { Context } from "#src/services/ctx.ts";
+import { logger } from "#src/services/logger.ts";
 
 // Currently only "turbo" is supported, but this can be extended in the future
 const decorators = ["turbo"] as const;

--- a/packages/run-run/src/program/commands/run.ts
+++ b/packages/run-run/src/program/commands/run.ts
@@ -1,5 +1,5 @@
 import { createCommand } from "commander";
-import type { Context } from "#/services/ctx";
+import type { Context } from "#src/services/ctx.ts";
 
 export function createRunCommand(ctx: Context) {
   return createCommand("run")

--- a/packages/run-run/src/program/commands/test-static.ts
+++ b/packages/run-run/src/program/commands/test-static.ts
@@ -1,6 +1,6 @@
 import { createCommand } from "commander";
-import { TOOL_LABELS } from "#/program/ui";
-import type { Context } from "#/services/ctx";
+import { TOOL_LABELS } from "#src/program/ui.ts";
+import type { Context } from "#src/services/ctx.ts";
 
 export function createTestStaticCommand(ctx: Context) {
   return createCommand("test:static")

--- a/packages/run-run/src/program/commands/tools.ts
+++ b/packages/run-run/src/program/commands/tools.ts
@@ -1,11 +1,11 @@
 import type { ShellService } from "@vlandoss/clibuddy";
 import { createCommand } from "commander";
-import { BiomeService } from "#/services/biome";
-import type { Context } from "#/services/ctx";
-import { OxfmtService } from "#/services/oxfmt";
-import { OxlintService } from "#/services/oxlint";
-import type { ToolService } from "#/services/tool";
-import { TsdownService } from "#/services/tsdown";
+import { BiomeService } from "#src/services/biome.ts";
+import type { Context } from "#src/services/ctx.ts";
+import { OxfmtService } from "#src/services/oxfmt.ts";
+import { OxlintService } from "#src/services/oxlint.ts";
+import type { ToolService } from "#src/services/tool.ts";
+import { TsdownService } from "#src/services/tsdown.ts";
 
 type ActionParams = {
   args: string[];

--- a/packages/run-run/src/program/commands/tscheck.ts
+++ b/packages/run-run/src/program/commands/tscheck.ts
@@ -1,9 +1,9 @@
 import { cwd, type ShellService } from "@vlandoss/clibuddy";
 import type { AnyLogger } from "@vlandoss/loggy";
 import { createCommand } from "commander";
-import type { Context } from "#/services/ctx";
-import { logger } from "#/services/logger";
-import { OxlintService } from "#/services/oxlint";
+import type { Context } from "#src/services/ctx.ts";
+import { logger } from "#src/services/logger.ts";
+import { OxlintService } from "#src/services/oxlint.ts";
 import { TOOL_LABELS } from "../ui";
 
 type TypecheckAtOptions = {

--- a/packages/run-run/src/program/index.ts
+++ b/packages/run-run/src/program/index.ts
@@ -1,18 +1,18 @@
 import { getVersion } from "@vlandoss/clibuddy";
 import { createCommand } from "commander";
-import { createContext } from "#/services/ctx";
-import { createBuildLibCommand } from "./commands/build-lib";
-import { createCleanCommand } from "./commands/clean";
-import { createConfigCommand } from "./commands/config";
-import { createFormatCommand } from "./commands/format";
-import { createJsCheckCommand } from "./commands/jscheck";
-import { createLintCommand } from "./commands/lint";
-import { createPkgsCommand } from "./commands/pkgs";
-import { createRunCommand } from "./commands/run";
-import { createTestStaticCommand } from "./commands/test-static";
-import { createToolsCommand } from "./commands/tools";
-import { createTsCheckCommand } from "./commands/tscheck";
-import { CREDITS_TEXT, getBannerText } from "./ui";
+import { createContext } from "#src/services/ctx.ts";
+import { createBuildLibCommand } from "./commands/build-lib.ts";
+import { createCleanCommand } from "./commands/clean.ts";
+import { createConfigCommand } from "./commands/config.ts";
+import { createFormatCommand } from "./commands/format.ts";
+import { createJsCheckCommand } from "./commands/jscheck.ts";
+import { createLintCommand } from "./commands/lint.ts";
+import { createPkgsCommand } from "./commands/pkgs.ts";
+import { createRunCommand } from "./commands/run.ts";
+import { createTestStaticCommand } from "./commands/test-static.ts";
+import { createToolsCommand } from "./commands/tools.ts";
+import { createTsCheckCommand } from "./commands/tscheck.ts";
+import { CREDITS_TEXT, getBannerText } from "./ui.ts";
 
 export type Options = {
   binDir: string;

--- a/packages/run-run/src/program/parse-args.ts
+++ b/packages/run-run/src/program/parse-args.ts
@@ -1,4 +1,4 @@
-import { logger } from "../services/logger";
+import { logger } from "../services/logger.ts";
 
 const debug = logger.subdebug("parseArgs");
 

--- a/packages/run-run/src/services/biome.ts
+++ b/packages/run-run/src/services/biome.ts
@@ -1,8 +1,8 @@
 import type { ShellService } from "@vlandoss/clibuddy";
 import isCI from "is-ci";
-import { TOOL_LABELS } from "#/program/ui";
-import type { FormatOptions, Formatter, Linter, LintOptions, StaticChecker, StaticCheckerOptions } from "#/types/tool";
-import { ToolService } from "./tool";
+import { TOOL_LABELS } from "#src/program/ui.ts";
+import type { FormatOptions, Formatter, Linter, LintOptions, StaticChecker, StaticCheckerOptions } from "#src/types/tool.ts";
+import { ToolService } from "./tool.ts";
 
 export class BiomeService extends ToolService implements Formatter, Linter, StaticChecker {
   constructor(shellService: ShellService) {

--- a/packages/run-run/src/services/config.ts
+++ b/packages/run-run/src/services/config.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import { type AsyncSearcher, lilconfig } from "lilconfig";
-import type { ExportedConfig, UserConfig } from "#/types/config";
-import { logger } from "./logger";
+import type { ExportedConfig, UserConfig } from "#src/types/config.ts";
+import { logger } from "./logger.ts";
 
 const DEFAULT_CONFIG: UserConfig = {
   future: {

--- a/packages/run-run/src/services/ctx.ts
+++ b/packages/run-run/src/services/ctx.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import { createPkgService, createShellService, cwd, type PkgService, type ShellService } from "@vlandoss/clibuddy";
-import type { ExportedConfig } from "#/types/config";
-import { ConfigService } from "./config";
-import { logger } from "./logger";
+import type { ExportedConfig } from "#src/types/config.ts";
+import { ConfigService } from "./config.ts";
+import { logger } from "./logger.ts";
 
 export type Context = {
   binPkg: PkgService;

--- a/packages/run-run/src/services/oxfmt.ts
+++ b/packages/run-run/src/services/oxfmt.ts
@@ -1,7 +1,7 @@
 import type { ShellService } from "@vlandoss/clibuddy";
-import { TOOL_LABELS } from "#/program/ui";
-import type { FormatOptions, Formatter } from "#/types/tool";
-import { ToolService } from "./tool";
+import { TOOL_LABELS } from "#src/program/ui.ts";
+import type { FormatOptions, Formatter } from "#src/types/tool.ts";
+import { ToolService } from "./tool.ts";
 
 export class OxfmtService extends ToolService implements Formatter {
   constructor(shellService: ShellService) {

--- a/packages/run-run/src/services/oxlint.ts
+++ b/packages/run-run/src/services/oxlint.ts
@@ -1,7 +1,7 @@
 import type { ShellService } from "@vlandoss/clibuddy";
-import { TOOL_LABELS } from "#/program/ui";
-import type { Linter, LintOptions } from "#/types/tool";
-import { ToolService } from "./tool";
+import { TOOL_LABELS } from "#src/program/ui.ts";
+import type { Linter, LintOptions } from "#src/types/tool.ts";
+import { ToolService } from "./tool.ts";
 
 export class OxlintService extends ToolService implements Linter {
   constructor(shellService: ShellService) {

--- a/packages/run-run/src/services/tool.ts
+++ b/packages/run-run/src/services/tool.ts
@@ -1,6 +1,6 @@
 import type { Shell, ShellService } from "@vlandoss/clibuddy";
 import memoize from "memoize";
-import { gracefullBinDir } from "#/utils/gracefullBinDir";
+import { gracefullBinDir } from "#src/utils/gracefullBinDir.ts";
 
 type CreateOptions = {
   bin: string;

--- a/packages/run-run/src/services/tsdown.ts
+++ b/packages/run-run/src/services/tsdown.ts
@@ -1,6 +1,6 @@
 import type { ShellService } from "@vlandoss/clibuddy";
-import { TOOL_LABELS } from "#/program/ui";
-import { ToolService } from "./tool";
+import { TOOL_LABELS } from "#src/program/ui.ts";
+import { ToolService } from "./tool.ts";
 
 export class TsdownService extends ToolService {
   constructor(shellService: ShellService) {

--- a/packages/run-run/src/utils/gracefullBinDir.ts
+++ b/packages/run-run/src/utils/gracefullBinDir.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { logger } from "#/services/logger";
+import { logger } from "#src/services/logger.ts";
 
 export function gracefullBinDir(binPathResolver: () => string) {
   try {

--- a/packages/run-run/test/helpers.ts
+++ b/packages/run-run/test/helpers.ts
@@ -1,7 +1,7 @@
 import { type Mock, mock } from "bun:test";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { createProgram } from "../src/program";
+import { createProgram } from "../src/program/index.ts";
 
 const execAsync = promisify(exec);
 

--- a/packages/run-run/tsconfig.json
+++ b/packages/run-run/tsconfig.json
@@ -1,11 +1,3 @@
 {
-  "extends": ["@total-typescript/tsconfig/bundler/no-dom/app"],
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "#/*": ["./src/*"],
-      "#test/*": ["./test/*"],
-      "@vlandoss/*": ["../../packages/*/src"]
-    }
-  }
+  "extends": ["@vlandoss/config/ts/no-dom/lib"]
 }

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -13,6 +13,9 @@
   "license": "MIT",
   "author": "rcrd <rcrd@variable.land>",
   "type": "module",
+  "imports": {
+    "#src/*": "./src/*"
+  },
   "module": "src/main.ts",
   "bin": {
     "vland": "./bin.ts"

--- a/packages/starter/plopfiles/plopfile.ts
+++ b/packages/starter/plopfiles/plopfile.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import type { NodePlopAPI } from "node-plop";
-import { ConfigService } from "#/services/config";
+import { ConfigService } from "#src/services/config.ts";
 import { tsconfigPrompts } from "./prompts/tsconfig";
 
 const validators = {

--- a/packages/starter/src/actions/add.ts
+++ b/packages/starter/src/actions/add.ts
@@ -1,5 +1,5 @@
-import { logger } from "#/services/logger";
-import type { TemplateService } from "#/services/types";
+import { logger } from "#src/services/logger.ts";
+import type { TemplateService } from "#src/services/types.ts";
 import type { AnyAction } from "./types";
 
 type CreateOptions = {

--- a/packages/starter/src/actions/init.ts
+++ b/packages/starter/src/actions/init.ts
@@ -1,6 +1,6 @@
 import type { ShellService } from "@vlandoss/clibuddy";
-import { logger } from "#/services/logger";
-import type { TemplateService } from "#/services/types";
+import { logger } from "#src/services/logger.ts";
+import type { TemplateService } from "#src/services/types.ts";
 import type { AnyAction } from "./types";
 
 type ExecuteOptions = {

--- a/packages/starter/src/main.ts
+++ b/packages/starter/src/main.ts
@@ -1,6 +1,6 @@
 import { run } from "@vlandoss/clibuddy";
-import { createProgram, type Options } from "./program";
-import { logger } from "./services/logger";
+import { createProgram, type Options } from "./program/index.ts";
+import { logger } from "./services/logger.ts";
 
 export async function main(options: Options) {
   await run(async () => {

--- a/packages/starter/src/program/commands/add.ts
+++ b/packages/starter/src/program/commands/add.ts
@@ -1,9 +1,9 @@
 import { cwd } from "@vlandoss/clibuddy";
 import { Argument, createCommand, Option } from "commander";
-import { AddAction } from "#/actions/add";
-import type { ContextValue } from "#/services/ctx";
-import { logger } from "#/services/logger";
-import { createPlopTemplateService } from "#/services/template";
+import { AddAction } from "#src/actions/add.ts";
+import type { ContextValue } from "#src/services/ctx.ts";
+import { logger } from "#src/services/logger.ts";
+import { createPlopTemplateService } from "#src/services/template.ts";
 
 type AddOptions = {
   dest: string;

--- a/packages/starter/src/program/commands/init.ts
+++ b/packages/starter/src/program/commands/init.ts
@@ -1,9 +1,9 @@
 import { cwd } from "@vlandoss/clibuddy";
 import { Argument, createCommand, Option } from "commander";
-import { InitAction } from "#/actions/init";
-import type { ContextValue } from "#/services/ctx";
-import { logger } from "#/services/logger";
-import { createPlopTemplateService } from "#/services/template";
+import { InitAction } from "#src/actions/init.ts";
+import type { ContextValue } from "#src/services/ctx.ts";
+import { logger } from "#src/services/logger.ts";
+import { createPlopTemplateService } from "#src/services/template.ts";
 
 type InitOptions = {
   dest: string;

--- a/packages/starter/src/program/index.ts
+++ b/packages/starter/src/program/index.ts
@@ -1,8 +1,8 @@
 import { getVersion } from "@vlandoss/clibuddy";
 import { Command } from "commander";
-import { createContext } from "#/services/ctx";
-import { createAddCommand } from "./commands/add";
-import { createInitCommand } from "./commands/init";
+import { createContext } from "#src/services/ctx.ts";
+import { createAddCommand } from "./commands/add.ts";
+import { createInitCommand } from "./commands/init.ts";
 import { BANNER_TEXT } from "./ui";
 
 export type Options = {

--- a/packages/starter/src/services/ctx.ts
+++ b/packages/starter/src/services/ctx.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { createPkgService, createShellService, type PkgService, type ShellService } from "@vlandoss/clibuddy";
-import { ConfigService } from "./config";
-import { logger } from "./logger";
+import { ConfigService } from "./config.ts";
+import { logger } from "./logger.ts";
 
 export type ContextValue = {
   binPkg: PkgService;

--- a/packages/starter/src/services/template.ts
+++ b/packages/starter/src/services/template.ts
@@ -1,8 +1,8 @@
 import { join } from "node:path";
 import type { NodePlopAPI } from "node-plop";
 import nodePlop from "node-plop";
-import { logger } from "./logger";
-import type { GenerateOptions, TemplateService } from "./types";
+import { logger } from "./logger.ts";
+import type { GenerateOptions, TemplateService } from "./types.ts";
 
 type CreateOptions = {
   basePath: string;

--- a/packages/starter/tsconfig.json
+++ b/packages/starter/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": ["@total-typescript/tsconfig/bundler/no-dom/app"],
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "#/*": ["./src/*"],
-      "@vlandoss/*": ["../../packages/*/src"]
-    }
-  }
+  "extends": ["@vlandoss/config/ts/no-dom/app"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@changesets/cli':
         specifier: 2.29.8
         version: 2.29.8(@types/node@25.6.0)
-      '@total-typescript/tsconfig':
-        specifier: 1.0.4
-        version: 1.0.4
       '@types/bun':
         specifier: latest
         version: 1.3.13


### PR DESCRIPTION
## Summary
- Replace `@total-typescript/tsconfig` extends with `@vlandoss/config/ts/*` across `run-run`, `starter`, `clibuddy`, `localproxy` and `loggy`
- Move path aliases from per-package `tsconfig.json` `paths` to Node `package.json` `imports` (`#src/*`, `#test/*`) in `run-run` and `starter`; update all `#/...` imports to `#src/...`
- Add explicit `.ts` extensions to relative imports across `run-run` and `starter`
- Drop the now-unused `@total-typescript/tsconfig` root devDependency

## Test plan
- [x] `pnpm rr test:static` passes (jscheck + tscheck across all packages)
- [x] `pnpm test` passes (`run-run` snapshots and `localproxy` unit tests)