### PR TITLE
docs(config): document vite/oxc tsconfig extends caveat

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -42,6 +42,18 @@ Available TypeScript presets:
 - `@vlandoss/config/ts/no-dom/app`
 - `@vlandoss/config/ts/no-dom/lib`
 
+### Caveat: `vite`/`oxc` + `pnpm` strict isolation
+
+The TypeScript presets extend `@total-typescript/tsconfig`. `tsc` and Node resolve transitive `extends` relative to the file that declares them (per the TS spec), but `vite`/`oxc` (used by `vitest` ≥ 4 via `rolldown`) resolves them from the **consumer**'s location instead. Under `pnpm`'s strict isolation, `@total-typescript/tsconfig` is reachable from this package but not from the consumer, so `oxc` errors with `Tsconfig not found`.
+
+Workaround — public-hoist the transitive base in the consumer's `.npmrc`:
+
+```
+public-hoist-pattern[]=@total-typescript/*
+```
+
+Not needed for `tsc`-only consumers.
+
 ## Lefthook
 
 Consumed via [lefthook remotes](https://lefthook.dev/examples/remotes) — no `pnpm add` needed.


### PR DESCRIPTION
## Summary
- Documents a non-obvious failure mode when consuming `@vlandoss/config`'s TypeScript presets from a `vite`/`oxc`-based stack (e.g. `vitest` ≥ 4) under `pnpm` strict isolation.
- Explains why `tsc` works but `oxc` errors with `Tsconfig not found`, and provides the `public-hoist-pattern[]=@total-typescript/*` workaround.

## Test plan
- [ ] Render the README on GitHub and confirm the new "Caveat" section reads correctly between the TypeScript presets list and the Lefthook section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)