### PR TITLE
chore: upgrade TypeScript to 6.0.3 and enforce explicit .ts import extensions

### DIFF
--- a/.changeset/cyan-tigers-run.md
+++ b/.changeset/cyan-tigers-run.md
@@ -1,0 +1,15 @@
+---
+"@vlandoss/config": minor
+"@vlandoss/run-run": patch
+"@vlandoss/localproxy": patch
+"@vlandoss/starter": patch
+---
+
+Upgrade TypeScript to 6.0.3 and enforce explicit `.ts` import extensions
+
+- Upgrade TypeScript from 5.9.3 to 6.0.3 across the monorepo
+- Add `useImportExtensions: "error"` biome rule to enforce explicit `.ts` extensions in all imports
+- Add `@types/node` as optional peer dependency in `@vlandoss/config`
+- Add `types: ["node"]` to the `tsconfig.no-dom` base config
+- Update all import paths in `localproxy` and `starter` to use explicit `.ts` extensions
+- Remove root-level `tsconfig.json` (paths now handled per-package)

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -39,10 +39,14 @@
     "@total-typescript/tsconfig": "1.0.4"
   },
   "peerDependencies": {
-    "@biomejs/biome": "2.4.4"
+    "@biomejs/biome": "2.4.4",
+    "@types/node": ">=20"
   },
   "peerDependenciesMeta": {
     "@biomejs/biome": {
+      "optional": true
+    },
+    "@types/node": {
       "optional": true
     }
   }

--- a/packages/config/src/biome/config.json
+++ b/packages/config/src/biome/config.json
@@ -25,6 +25,9 @@
       },
       "complexity": {
         "noStaticOnlyClass": "off"
+      },
+      "correctness": {
+        "useImportExtensions": "error"
       }
     }
   },

--- a/packages/config/src/ts/tsconfig.no-dom.json
+++ b/packages/config/src/ts/tsconfig.no-dom.json
@@ -1,6 +1,7 @@
 {
   "extends": ["@total-typescript/tsconfig/bundler/no-dom"],
   "compilerOptions": {
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
   }
 }

--- a/packages/localproxy/bin.ts
+++ b/packages/localproxy/bin.ts
@@ -2,7 +2,7 @@
 import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { main } from "./src/main";
+import { main } from "./src/main.ts";
 
 main({
   binDir: path.dirname(fileURLToPath(import.meta.url)),

--- a/packages/localproxy/src/commands/clean.ts
+++ b/packages/localproxy/src/commands/clean.ts
@@ -1,9 +1,9 @@
 import { createCommand } from "commander";
-import { CaddyService } from "#/services/caddy";
-import { CaddyfileService } from "#/services/caddyfile";
-import { HostsService } from "#/services/hosts";
-import { logger } from "#/services/logger";
-import type { Context } from "#/types";
+import { CaddyService } from "#/services/caddy.ts";
+import { CaddyfileService } from "#/services/caddyfile/index.ts";
+import { HostsService } from "#/services/hosts.ts";
+import { logger } from "#/services/logger.ts";
+import type { Context } from "#/types.ts";
 
 type CommandOptions = {
   verbose: boolean;

--- a/packages/localproxy/src/commands/setup.ts
+++ b/packages/localproxy/src/commands/setup.ts
@@ -2,13 +2,13 @@ import * as fs from "node:fs/promises";
 import path from "node:path";
 import { editor as editorPrompt } from "@inquirer/prompts";
 import { createCommand } from "commander";
-import { CaddyService } from "#/services/caddy";
-import { CaddyfileService } from "#/services/caddyfile";
-import { FileService } from "#/services/file";
-import { HostsService } from "#/services/hosts";
-import { logger } from "#/services/logger";
-import { quietShell } from "#/services/shell";
-import type { Context } from "#/types";
+import { CaddyService } from "#/services/caddy.ts";
+import { CaddyfileService } from "#/services/caddyfile/index.ts";
+import { FileService } from "#/services/file.ts";
+import { HostsService } from "#/services/hosts.ts";
+import { logger } from "#/services/logger.ts";
+import { quietShell } from "#/services/shell.ts";
+import type { Context } from "#/types.ts";
 
 type CommandOptions = {
   verbose: boolean;

--- a/packages/localproxy/src/commands/start.ts
+++ b/packages/localproxy/src/commands/start.ts
@@ -1,7 +1,7 @@
 import { createCommand } from "commander";
-import { CaddyService } from "#/services/caddy";
-import { logger } from "#/services/logger";
-import type { Context } from "#/types";
+import { CaddyService } from "#/services/caddy.ts";
+import { logger } from "#/services/logger.ts";
+import type { Context } from "#/types.ts";
 
 type CommandOptions = {
   verbose: boolean;

--- a/packages/localproxy/src/commands/status.ts
+++ b/packages/localproxy/src/commands/status.ts
@@ -1,10 +1,10 @@
 import { createCommand } from "commander";
-import { CaddyService } from "#/services/caddy";
-import { CaddyfileService } from "#/services/caddyfile";
-import { FileService } from "#/services/file";
-import { HostsService } from "#/services/hosts";
-import { logger } from "#/services/logger";
-import type { Context } from "#/types";
+import { CaddyService } from "#/services/caddy.ts";
+import { CaddyfileService } from "#/services/caddyfile/index.ts";
+import { FileService } from "#/services/file.ts";
+import { HostsService } from "#/services/hosts.ts";
+import { logger } from "#/services/logger.ts";
+import type { Context } from "#/types.ts";
 
 export function createStatusCommand({ caddyfilePath }: Context) {
   return createCommand("status")

--- a/packages/localproxy/src/commands/stop.ts
+++ b/packages/localproxy/src/commands/stop.ts
@@ -1,7 +1,7 @@
 import { createCommand } from "commander";
-import { CaddyService } from "#/services/caddy";
-import { logger } from "#/services/logger";
-import type { Context } from "#/types";
+import { CaddyService } from "#/services/caddy.ts";
+import { logger } from "#/services/logger.ts";
+import type { Context } from "#/types.ts";
 
 type CommandOptions = {
   verbose: boolean;

--- a/packages/localproxy/src/main.ts
+++ b/packages/localproxy/src/main.ts
@@ -1,14 +1,14 @@
 import path from "node:path";
 import { createPkgService, getVersion } from "@vlandoss/clibuddy";
 import { createCommand } from "commander";
-import { createCleanCommand } from "./commands/clean";
-import { createSetupCommand } from "./commands/setup";
-import { createStartCommand } from "./commands/start";
-import { createStatusCommand } from "./commands/status";
-import { createStopCommand } from "./commands/stop";
-import { logger } from "./services/logger";
-import type { Context, ProgramOptions } from "./types";
-import { BANNER_TEXT, CREDITS_TEXT } from "./ui";
+import { createCleanCommand } from "./commands/clean.ts";
+import { createSetupCommand } from "./commands/setup.ts";
+import { createStartCommand } from "./commands/start.ts";
+import { createStatusCommand } from "./commands/status.ts";
+import { createStopCommand } from "./commands/stop.ts";
+import { logger } from "./services/logger.ts";
+import type { Context, ProgramOptions } from "./types.ts";
+import { BANNER_TEXT, CREDITS_TEXT } from "./ui.ts";
 
 async function createContext({ binDir, installDir }: ProgramOptions) {
   const binPkg = await createPkgService(binDir);

--- a/packages/localproxy/src/services/caddy.ts
+++ b/packages/localproxy/src/services/caddy.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import path from "node:path";
-import { logger } from "./logger";
-import { quietShell, silentShell, verboseShell } from "./shell";
+import { logger } from "./logger.ts";
+import { quietShell, silentShell, verboseShell } from "./shell.ts";
 
 const debug = logger.subdebug("caddy");
 

--- a/packages/localproxy/src/services/caddyfile/__tests__/caddyfile.test.ts
+++ b/packages/localproxy/src/services/caddyfile/__tests__/caddyfile.test.ts
@@ -1,9 +1,9 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { CaddyfileService, type LocalDomain } from "#/services/caddyfile";
-import { type Caddyfile, CaddyfileParser } from "#/services/caddyfile/parser";
-import { FixtureReader } from "./helpers";
+import { CaddyfileService, type LocalDomain } from "#/services/caddyfile/index.ts";
+import { type Caddyfile, CaddyfileParser } from "#/services/caddyfile/parser.ts";
+import { FixtureReader } from "./helpers.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixtureReader = new FixtureReader(__dirname);

--- a/packages/localproxy/src/services/caddyfile/index.ts
+++ b/packages/localproxy/src/services/caddyfile/index.ts
@@ -1,1 +1,1 @@
-export * from "./service";
+export * from "./service.ts";

--- a/packages/localproxy/src/services/caddyfile/service.ts
+++ b/packages/localproxy/src/services/caddyfile/service.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
-import { logger } from "../logger";
-import { CaddyfileParser } from "./parser";
+import { logger } from "../logger.ts";
+import { CaddyfileParser } from "./parser.ts";
 
 const debug = logger.subdebug("caddyfile-service");
 

--- a/packages/localproxy/src/services/hosts.ts
+++ b/packages/localproxy/src/services/hosts.ts
@@ -1,6 +1,6 @@
-import { logger } from "./logger";
-import { quietShell, silentShell, verboseShell } from "./shell";
-import { SudoService } from "./sudo";
+import { logger } from "./logger.ts";
+import { quietShell, silentShell, verboseShell } from "./shell.ts";
+import { SudoService } from "./sudo.ts";
 
 type SetupOptions = {
   verbose: boolean;

--- a/packages/localproxy/src/services/sudo.ts
+++ b/packages/localproxy/src/services/sudo.ts
@@ -1,7 +1,7 @@
 import { password as passwordPrompt } from "@inquirer/prompts";
 import type { ShellService } from "@vlandoss/clibuddy";
-import { logger } from "./logger";
-import { silentShell } from "./shell";
+import { logger } from "./logger.ts";
+import { silentShell } from "./shell.ts";
 
 const debug = logger.subdebug("sudo");
 

--- a/packages/localproxy/tsconfig.json
+++ b/packages/localproxy/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": ["@vlandoss/config/ts/no-dom/app"],
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "#/*": ["./src/*"],
-      "@vlandoss/*": ["../../packages/*/src"]
-    }
-  }
+  "extends": ["@vlandoss/config/ts/no-dom/app"]
 }

--- a/packages/run-run/package.json
+++ b/packages/run-run/package.json
@@ -60,7 +60,7 @@
     "oxlint-tsgolint": "0.15.0",
     "rimraf": "6.1.3",
     "tsdown": "0.21.10",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/starter/bin.ts
+++ b/packages/starter/bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { main } from "./src/main";
+import { main } from "./src/main.ts";
 
 main({
   binDir: dirname(fileURLToPath(import.meta.url)),

--- a/packages/starter/plopfiles/plopfile.ts
+++ b/packages/starter/plopfiles/plopfile.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import type { NodePlopAPI } from "node-plop";
 import { ConfigService } from "#src/services/config.ts";
-import { tsconfigPrompts } from "./prompts/tsconfig";
+import { tsconfigPrompts } from "./prompts/tsconfig.ts";
 
 const validators = {
   atLeastOne: (answer: string[]) => {

--- a/packages/starter/src/actions/add.ts
+++ b/packages/starter/src/actions/add.ts
@@ -1,6 +1,6 @@
 import { logger } from "#src/services/logger.ts";
 import type { TemplateService } from "#src/services/types.ts";
-import type { AnyAction } from "./types";
+import type { AnyAction } from "./types.ts";
 
 type CreateOptions = {
   templateService: TemplateService;

--- a/packages/starter/src/actions/init.ts
+++ b/packages/starter/src/actions/init.ts
@@ -1,7 +1,7 @@
 import type { ShellService } from "@vlandoss/clibuddy";
 import { logger } from "#src/services/logger.ts";
 import type { TemplateService } from "#src/services/types.ts";
-import type { AnyAction } from "./types";
+import type { AnyAction } from "./types.ts";
 
 type ExecuteOptions = {
   template?: string;

--- a/packages/starter/src/program/index.ts
+++ b/packages/starter/src/program/index.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { createContext } from "#src/services/ctx.ts";
 import { createAddCommand } from "./commands/add.ts";
 import { createInitCommand } from "./commands/init.ts";
-import { BANNER_TEXT } from "./ui";
+import { BANNER_TEXT } from "./ui.ts";
 
 export type Options = {
   binDir: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 2.1.1
       tsdown:
         specifier: 0.21.10
-        version: 0.21.10(typescript@5.9.3)
+        version: 0.21.10(typescript@6.0.3)
       turbo:
         specifier: 2.8.12
         version: 2.8.12
@@ -75,6 +75,9 @@ importers:
       '@total-typescript/tsconfig':
         specifier: 1.0.4
         version: 1.0.4
+      '@types/node':
+        specifier: '>=20'
+        version: 25.6.0
 
   packages/localproxy:
     dependencies:
@@ -151,10 +154,10 @@ importers:
         version: 6.1.3
       tsdown:
         specifier: 0.21.10
-        version: 0.21.10(typescript@5.9.3)
+        version: 0.21.10(typescript@6.0.3)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
     devDependencies:
       '@vlandoss/tsdown-config':
         specifier: workspace:^
@@ -183,7 +186,7 @@ importers:
     dependencies:
       tsdown:
         specifier: ^0.21.10
-        version: 0.21.10(typescript@5.9.3)
+        version: 0.21.10(typescript@6.0.3)
 
 packages:
 
@@ -3635,8 +3638,8 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3700,6 +3703,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -7200,7 +7204,7 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -7214,7 +7218,7 @@ snapshots:
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.17
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -7508,7 +7512,7 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  tsdown@0.21.10(typescript@5.9.3):
+  tsdown@0.21.10(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -7519,7 +7523,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3)
       semver: 7.7.4
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
@@ -7527,7 +7531,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.37
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -7580,7 +7584,7 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "compilerOptions": {
-    "paths": {
-      "@vlandoss/run-run/*": ["./packages/run-run/src/lib/*"]
-    }
-  }
-}


### PR DESCRIPTION
## Summary

- Upgrade TypeScript from 5.9.3 to 6.0.3 across the monorepo
- Add `useImportExtensions: "error"` biome rule to enforce explicit `.ts` extensions in all local imports
- Add `@types/node` as optional peer dependency in `@vlandoss/config` and set `types: ["node"]` in the base tsconfig
- Update all import paths in `localproxy` and `starter` to use explicit `.ts` extensions
- Remove root-level `tsconfig.json` (paths now resolved per-package via tsconfig)