### PR TITLE
fix(ci): trigger preview job when 'preview' label is added to a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
 
@@ -70,7 +71,7 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ startsWith(github.head_ref, 'feat') || startsWith(github.head_ref, 'fix') }}
+    if: ${{ startsWith(github.head_ref, 'feat') || startsWith(github.head_ref, 'fix') || contains(github.event.pull_request.labels.*.name, 'preview') }}
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Problem

The `preview` job only runs on branches starting with `feat/` or `fix/`. PRs using other prefixes (e.g. `chore/`) have no way to trigger a preview release.

## Fix

Two minimal changes to `ci.yml`:

1. **Add `labeled` to `pull_request` event types** — so the workflow re-evaluates when a label is added to a PR.
2. **Extend the `preview` job condition** — to also run when the PR has a `preview` label, regardless of branch name.

```diff
  pull_request:
+   types: [opened, synchronize, reopened, labeled]
    branches:
      - main
```

```diff
- if: ${{ startsWith(github.head_ref, 'feat') || startsWith(github.head_ref, 'fix') }}
+ if: ${{ startsWith(github.head_ref, 'feat') || startsWith(github.head_ref, 'fix') || contains(github.event.pull_request.labels.*.name, 'preview') }}
```

## Usage

Add the `preview` label to any PR to trigger a preview release, regardless of the branch naming convention.