### PR TITLE
fix(run-run): add missing tsdown bin alias

### DIFF
--- a/.changeset/run-run-tsdown-bin.md
+++ b/.changeset/run-run-tsdown-bin.md
@@ -1,0 +1,5 @@
+---
+"@vlandoss/run-run": patch
+---
+
+fix: add missing `tsdown` bin alias to package.json

--- a/packages/run-run/package.json
+++ b/packages/run-run/package.json
@@ -27,7 +27,8 @@
     "run-run": "./bin.ts",
     "biome": "./tools/biome",
     "oxfmt": "./tools/oxfmt",
-    "oxlint": "./tools/oxlint"
+    "oxlint": "./tools/oxlint",
+    "tsdown": "./tools/tsdown"
   },
   "files": [
     "bin.ts",
@@ -79,7 +80,8 @@
       "run-run": "./dist/bin.mjs",
       "biome": "./tools/biome",
       "oxfmt": "./tools/oxfmt",
-      "oxlint": "./tools/oxlint"
+      "oxlint": "./tools/oxlint",
+      "tsdown": "./tools/tsdown"
     }
   },
   "engines": {


### PR DESCRIPTION
## Summary

- `tsdown` binary existed in `tools/tsdown` but was missing from `bin` and `publishConfig.bin` in `package.json`
- Adds `"tsdown": "./tools/tsdown"` following the same pattern as `biome`, `oxfmt`, and `oxlint`