### PR TITLE
fix(cli): correct binDir resolution in compiled binaries

### DIFF
--- a/.changeset/fix-bindir-dist-path.md
+++ b/.changeset/fix-bindir-dist-path.md
@@ -1,0 +1,12 @@
+---
+"@vlandoss/run-run": patch
+"@vlandoss/localproxy": patch
+"@vlandoss/starter": patch
+"@vlandoss/tsdown-config": patch
+---
+
+Fix `binDir` pointing to `dist/` in compiled CLIs
+
+When a CLI was published and executed via the compiled binary, `import.meta.url` resolved to the `dist/` folder, causing `binDir` to be `<root>/dist/` instead of the package root. This broke `localBaseBinPath` (which expects `<root>/node_modules/.bin`) and any other logic anchored to the package root.
+
+The fix introduces a thin `bin.mjs` wrapper at the package root that computes `binDir` from its own location (always the root) and imports the compiled logic from `dist/main.mjs`. The `tsdown-config` entry point is updated accordingly from `bin.ts` to `src/main.ts`.

--- a/packages/localproxy/bin.mjs
+++ b/packages/localproxy/bin.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { homedir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { main } from "./dist/main.mjs";
+
+main({
+  binDir: path.dirname(fileURLToPath(import.meta.url)),
+  installDir: path.join(homedir(), ".localproxy"),
+});

--- a/packages/localproxy/package.json
+++ b/packages/localproxy/package.json
@@ -22,7 +22,7 @@
     "localp": "./bin.ts"
   },
   "files": [
-    "bin.ts",
+    "bin.mjs",
     "dist",
     "src",
     "!src/**/__tests__",
@@ -46,8 +46,8 @@
   "publishConfig": {
     "access": "public",
     "bin": {
-      "localproxy": "./dist/bin.mjs",
-      "localp": "./dist/bin.mjs"
+      "localproxy": "./bin.mjs",
+      "localp": "./bin.mjs"
     }
   },
   "engines": {

--- a/packages/run-run/bin.mjs
+++ b/packages/run-run/bin.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { main } from "./dist/main.mjs";
+
+main({
+  binDir: dirname(fileURLToPath(import.meta.url)),
+});

--- a/packages/run-run/package.json
+++ b/packages/run-run/package.json
@@ -31,7 +31,7 @@
     "tsdown": "./tools/tsdown"
   },
   "files": [
-    "bin.ts",
+    "bin.mjs",
     "dist",
     "src",
     "!src/**/__tests__",
@@ -76,8 +76,8 @@
       }
     },
     "bin": {
-      "rr": "./dist/bin.mjs",
-      "run-run": "./dist/bin.mjs",
+      "rr": "./bin.mjs",
+      "run-run": "./bin.mjs",
       "biome": "./tools/biome",
       "oxfmt": "./tools/oxfmt",
       "oxlint": "./tools/oxlint",

--- a/packages/run-run/test/integration/node-compat.test.ts
+++ b/packages/run-run/test/integration/node-compat.test.ts
@@ -2,9 +2,9 @@ import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { expect, test } from "vitest";
 
-const bin = resolve(import.meta.dirname, "../../dist/bin.mjs");
+const bin = resolve(import.meta.dirname, "../../bin.mjs");
 
-test("node dist/bin.mjs --help exits 0", () => {
+test("node bin.mjs --help exits 0", () => {
   const result = spawnSync("node", [bin, "--help"], { encoding: "utf8" });
 
   expect(result.stderr).toBe("");

--- a/packages/starter/bin.mjs
+++ b/packages/starter/bin.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { main } from "./dist/main.mjs";
+
+main({
+  binDir: dirname(fileURLToPath(import.meta.url)),
+});

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -22,7 +22,7 @@
     "vland": "./bin.ts"
   },
   "files": [
-    "bin.ts",
+    "bin.mjs",
     "dist",
     "src",
     "!src/**/__tests__",
@@ -44,7 +44,7 @@
   "publishConfig": {
     "access": "public",
     "bin": {
-      "vland": "./dist/bin.mjs"
+      "vland": "./bin.mjs"
     }
   },
   "engines": {

--- a/packages/tsdown-config/src/index.ts
+++ b/packages/tsdown-config/src/index.ts
@@ -2,7 +2,7 @@ import { defineConfig, type UserConfig } from "tsdown";
 
 export function defineBinConfig(options: UserConfig = {}) {
   return defineConfig({
-    entry: ["bin.ts"],
+    entry: ["src/main.ts"],
     format: "esm",
     ...options,
   });


### PR DESCRIPTION
## Summary

- `binDir` apuntaba a `<root>/dist/` en vez de `<root>/` al ejecutar el binario compilado, porque `import.meta.url` resolvía desde dentro de `dist/`
- Esto rompía `localBaseBinPath` (buscaba `dist/node_modules/.bin`) y cualquier lógica anclada a la raíz del paquete
- El fix introduce un `bin.mjs` en la raíz de cada CLI que calcula `binDir` desde su propia ubicación (siempre la raíz) e importa la lógica compilada desde `dist/main.mjs`
- `tsdown-config` actualiza el entry de `bin.ts` a `src/main.ts` para que el output sea `dist/main.mjs`

## Packages afectados

- `@vlandoss/run-run` — patch
- `@vlandoss/localproxy` — patch
- `@vlandoss/starter` — patch
- `@vlandoss/tsdown-config` — patch