### PR TITLE
fix(config): invoke turbo via pnpm in lefthook hooks

### DIFF
--- a/packages/config/src/lefthook/turborepo.yml
+++ b/packages/config/src/lefthook/turborepo.yml
@@ -6,7 +6,7 @@ pre-commit:
       stage_fixed: true
 
     - name: tscheck
-      run: turbo run test:types --filter='...[HEAD]'
+      run: pnpm turbo run test:types --filter='...[HEAD]'
       glob:
         - "*.{ts,tsx}"
         - "tsconfig.json"
@@ -18,7 +18,7 @@ pre-push:
         branch="$(git branch --show-current)"
 
         if [ "$branch" = "main" ]; then
-          turbo run test --filter='...[HEAD^]'
+          pnpm turbo run test --filter='...[HEAD^]'
         else
-          turbo run test --affected
+          pnpm turbo run test --affected
         fi


### PR DESCRIPTION
## Summary
- Prefix `turbo` invocations in the shared lefthook config with `pnpm` so the hooks resolve turbo via the workspace instead of relying on a global install.

## Test plan
- [x] Run `pnpm lefthook run pre-commit` in a consumer repo and confirm `tscheck` executes successfully.
- [x] Run `pnpm lefthook run pre-push` on both `main` and a feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)