### PR TITLE
ci: use vland-bot GitHub App token for release and cli-docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,17 @@ jobs:
       packages: write
       pull-requests: write
     steps:
+      - name: 🔑 Mint vland-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VLAND_BOT_APP_ID }}
+          private-key: ${{ secrets.VLAND_BOT_PRIVATE_KEY }}
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v6
@@ -65,7 +74,7 @@ jobs:
           title: "chore: update versions"
           publish: pnpm changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           LEFTHOOK: 0
 
   preview:

--- a/.github/workflows/cli-docs.yml
+++ b/.github/workflows/cli-docs.yml
@@ -28,10 +28,18 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: 🔑 Mint vland-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.VLAND_BOT_APP_ID }}
+          private-key: ${{ secrets.VLAND_BOT_PRIVATE_KEY }}
+
       - name: ⬇️ Checkout main
         uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v6
@@ -75,7 +83,7 @@ jobs:
       - name: 🚀 Open or update rolling PR
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: automation/cli-docs
           base: main
           commit-message: "chore: regenerate CLI docs"


### PR DESCRIPTION
## Summary
- Mint a `vland-bot` installation token via `actions/create-github-app-token@v1` in both `ci.yml` (`release` job) and `cli-docs.yml`, and use it in place of the default `GITHUB_TOKEN`.
- `changesets/action` now publishes tags/releases as `vland-bot[bot]`; `peter-evans/create-pull-request` opens the rolling cli-docs PR as `vland-bot[bot]`.

## Why
Events triggered by `GITHUB_TOKEN` do not start downstream workflow runs. That's why:
- `cli-docs.yml` never fired after the `@vlandoss/run-run@0.3.0` and `@vlandoss/run-run@0.4.0` tag pushes — the changesets job created those tags with `GITHUB_TOKEN`.
- The rolling `automation/cli-docs` PR never had CI status checks.

GitHub App installation tokens are not subject to that protection, so:
- The release tag push will now trigger `cli-docs.yml` automatically.
- The rolling PR will get normal CI runs.

## Required setup before merge
1. Create repo (or org) secrets:
   - `VLAND_BOT_APP_ID` — the App's numeric ID
   - `VLAND_BOT_PRIVATE_KEY` — the full `.pem` (BEGIN/END lines included)
2. Confirm the `vland-bot` App is installed on `variableland/dx` with `Contents: Read & write` and `Pull requests: Read & write`.
3. If branch protection on `main` restricts pushes/tags by bots, add `vland-bot[bot]` to the bypass list (the publish step pushes tags directly, no PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)