### PR TITLE
ci: author release commits as vland-bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,18 @@ jobs:
       - name: ⌛ Setup pnpm
         uses: variableland/gh-actions/actions/setup-pnpm@main
 
+      - name: 🧑‍💻 Configure git user
+        run: |
+          git config user.name "vland-bot[bot]"
+          git config user.email "282456776+vland-bot[bot]@users.noreply.github.com"
+
       - name: 🚀 Create release PR or publish versions
         uses: changesets/action@v1
         with:
           commit: "chore: update versions"
           title: "chore: update versions"
           publish: pnpm changeset publish
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           LEFTHOOK: 0


### PR DESCRIPTION
## Summary
- Disable `changesets/action`'s default `setupGitUser` so it doesn't hardcode the author to `github-actions[bot]`.
- Configure git user as `vland-bot[bot]` (id `282456776`) before the action runs, so the `chore: update versions` PR commits are authored by vland-bot to match the PR opener.

## Test plan
- [ ] Merge to `main` and verify the next `chore: update versions` PR has commits authored by `vland-bot[bot]` instead of `github-actions[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)