### PR TITLE
feat(starter): add shell completion to vland CLI

### DIFF
--- a/.changeset/starter-completion.md
+++ b/.changeset/starter-completion.md
@@ -1,0 +1,5 @@
+---
+"@vlandoss/starter": minor
+---
+
+Add shell completion support to the `vland` CLI via a new `completion <shell>` subcommand (bash/zsh/fish), powered by [`usage`](https://usage.jdx.dev).

--- a/.github/workflows/cli-docs.yml
+++ b/.github/workflows/cli-docs.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - "@vlandoss/run-run@*"
+      - "@vlandoss/starter@*"
   workflow_dispatch:
 
 # Serialize runs so concurrent CLI tag pushes don't race on the rolling PR branch.
@@ -20,6 +21,7 @@ env:
   # output is written to `<dir>/CLI.md`.
   REGISTRY: |
     packages/run-run
+    packages/starter
 
 jobs:
   regen:

--- a/packages/starter/README.md
+++ b/packages/starter/README.md
@@ -16,14 +16,35 @@ It will adds the `vland` to your global workspace
 
 ## Usage
 
-> [!NOTE]
-> The documentation is WIP
-
 Run the help command:
 
 ```sh
 vland help
 ```
+
+## Shell completion
+
+`vland` ships a `completion` subcommand that prints a shell-specific script. Add it to your shell rc file:
+
+```sh
+# zsh — ~/.zshrc
+eval "$(vland completion zsh)"
+
+# bash — ~/.bashrc
+eval "$(vland completion bash)"
+
+# fish — ~/.config/fish/config.fish
+vland completion fish | source
+```
+
+**Prerequisite:** the [`usage`](https://usage.jdx.dev) CLI must be on your `PATH` (it powers completion at runtime). Install via one of:
+
+```sh
+mise use -g usage
+brew install usage
+```
+
+When you upgrade `@vlandoss/starter`, the next shell session will pick up new commands automatically — no need to re-run anything.
 
 ## Troubleshooting
 

--- a/packages/starter/bin
+++ b/packages/starter/bin
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  TARGET="$(readlink "$SOURCE")"
+  case "$TARGET" in
+    /*) SOURCE="$TARGET" ;;
+    *) SOURCE="$(dirname "$SOURCE")/$TARGET" ;;
+  esac
+done
+DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+
+if [ "$1" = "completion" ]; then
+  case "$2" in
+    bash | zsh | fish)
+      kdl="$DIR/dist/cli.usage.kdl"
+      if [ ! -f "$kdl" ]; then
+        echo "vland completion: missing $kdl. Reinstall @vlandoss/starter or run \`pnpm build\`." >&2
+        exit 1
+      fi
+      if ! command -v usage >/dev/null 2>&1; then
+        echo "vland completion: 'usage' CLI not found in PATH." >&2
+        echo "Install via: mise use -g usage  |  brew install usage" >&2
+        exit 1
+      fi
+      exec usage generate completion "$2" vland --file "$kdl"
+      ;;
+  esac
+  # Unknown shell or `--help`: fall through to Node so Commander prints help/errors.
+fi
+
+# In the source repo (tsdown.config.ts present, NOT shipped in the npm tarball),
+# always run from src/ so live edits show up. In a published install, use the
+# bundled dist/run.mjs.
+if [ -f "$DIR/tsdown.config.ts" ]; then
+  exec node "$DIR/src/run.ts" "$@"
+else
+  exec node "$DIR/dist/run.mjs" "$@"
+fi

--- a/packages/starter/bin.mjs
+++ b/packages/starter/bin.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import "./dist/run.mjs";

--- a/packages/starter/bin.ts
+++ b/packages/starter/bin.ts
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import "./src/run.ts";

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -19,10 +19,10 @@
   },
   "module": "src/main.ts",
   "bin": {
-    "vland": "./bin.ts"
+    "vland": "./bin"
   },
   "files": [
-    "bin.mjs",
+    "bin",
     "dist",
     "src",
     "!src/**/__tests__",
@@ -31,11 +31,13 @@
     "tsconfig.json"
   ],
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && pnpm build:kdl",
+    "build:kdl": "./bin --usage > dist/cli.usage.kdl",
     "prepublishOnly": "pnpm build",
     "test:types": "rr tsc"
   },
   "dependencies": {
+    "@usage-spec/commander": "1.1.0",
     "@vlandoss/clibuddy": "workspace:*",
     "@vlandoss/loggy": "workspace:*",
     "commander": "14.0.3",
@@ -44,7 +46,7 @@
   "publishConfig": {
     "access": "public",
     "bin": {
-      "vland": "./bin.mjs"
+      "vland": "./bin"
     }
   },
   "engines": {

--- a/packages/starter/src/program/commands/completion.ts
+++ b/packages/starter/src/program/commands/completion.ts
@@ -1,0 +1,26 @@
+import { Argument, createCommand } from "commander";
+import { TOOL_LABELS } from "../ui.ts";
+
+const SHELLS = ["bash", "zsh", "fish"] as const;
+
+// Ghost command: registered with Commander purely for discoverability — it surfaces
+// in `vland --help` and is baked into dist/cli.usage.kdl so the completion itself can
+// suggest "completion" after `vland <TAB>`. The actual handler lives in the bash bin
+// dispatcher, which intercepts `vland completion <shell>` before reaching Node.
+export function createCompletionCommand() {
+  return createCommand("completion")
+    .summary(`print shell completion script 🐚 (${TOOL_LABELS.USAGE})`)
+    .description(
+      `Prints a shell completion script for vland. Add to your shell rc file:
+
+  bash: eval "$(vland completion bash)"
+  zsh:  eval "$(vland completion zsh)"
+  fish: vland completion fish | source`,
+    )
+    .addArgument(new Argument("<shell>", `target shell`).choices(SHELLS))
+    .addHelpText(
+      "afterAll",
+      `\nUnder the hood, this command uses ${TOOL_LABELS.USAGE} (https://usage.jdx.dev).
+Make sure to have it installed and available in your PATH.`,
+    );
+}

--- a/packages/starter/src/program/commands/usage.ts
+++ b/packages/starter/src/program/commands/usage.ts
@@ -1,0 +1,9 @@
+import { generateToStdout } from "@usage-spec/commander";
+import { type Command, Option } from "commander";
+
+export function addUsage(program: Command) {
+  return program.addOption(new Option("--usage", "print KDL spec for this CLI (https://kdl.dev)")).on("option:usage", () => {
+    generateToStdout(program);
+    process.exit(0);
+  });
+}

--- a/packages/starter/src/program/index.ts
+++ b/packages/starter/src/program/index.ts
@@ -2,7 +2,9 @@ import { getVersion } from "@vlandoss/clibuddy";
 import { Command } from "commander";
 import { createContext } from "#src/services/ctx.ts";
 import { createAddCommand } from "./commands/add.ts";
+import { createCompletionCommand } from "./commands/completion.ts";
 import { createInitCommand } from "./commands/init.ts";
+import { addUsage } from "./commands/usage.ts";
 import { getBannerText } from "./ui.ts";
 
 export type Options = {
@@ -13,9 +15,12 @@ export async function createProgram(options: Options) {
   const ctx = await createContext(options.binDir);
   const version = getVersion(ctx.binPkg);
 
-  return new Command("vland")
-    .version(version, "-v, --version")
-    .addHelpText("before", getBannerText(version))
-    .addCommand(createInitCommand(ctx))
-    .addCommand(createAddCommand(ctx));
+  return addUsage(
+    new Command("vland")
+      .version(version, "-v, --version")
+      .addHelpText("before", getBannerText(version))
+      .addCommand(createCompletionCommand())
+      .addCommand(createInitCommand(ctx))
+      .addCommand(createAddCommand(ctx)),
+  );
 }

--- a/packages/starter/src/program/ui.ts
+++ b/packages/starter/src/program/ui.ts
@@ -1,6 +1,11 @@
 import { colorize, palette, text } from "@vlandoss/clibuddy";
 
 const vlandColor = colorize("#a78bfa");
+const usageColor = colorize("#24C55E");
+
+export const TOOL_LABELS = {
+  USAGE: usageColor("usage"),
+};
 
 // npx figlet -f "ANSI Shadow" "vland"
 export function getBannerText(version: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
 
   packages/starter:
     dependencies:
+      '@usage-spec/commander':
+        specifier: 1.1.0
+        version: 1.1.0
       '@vlandoss/clibuddy':
         specifier: workspace:*
         version: link:../clibuddy


### PR DESCRIPTION
## Summary

- Adds a `completion <shell>` subcommand to `vland` (bash/zsh/fish), mirroring the run-run setup.
- Replaces `bin.ts` / `bin.mjs` with a single bash dispatcher (`packages/starter/bin`) that intercepts `vland completion <shell>` and shells out to the [`usage`](https://usage.jdx.dev) CLI using a bundled `dist/cli.usage.kdl`.
- Adds a hidden `--usage` flag (powered by `@usage-spec/commander`) used by `build:kdl` to generate the spec, plus a ghost Commander subcommand so completion is discoverable in `--help` and in the KDL.
- Registers `packages/starter` in `.github/workflows/cli-docs.yml` so `CLI.md` regenerates on each `@vlandoss/starter@*` release tag.

## Test plan

- [x] `pnpm --filter @vlandoss/starter build` produces `dist/cli.usage.kdl`
- [x] `pnpm --filter @vlandoss/starter test:types` passes
- [x] `./bin --help` shows the new `completion` command
- [x] `./bin completion zsh` prints a valid zsh completion script
- [ ] After merge + release tag: cli-docs workflow regenerates `packages/starter/CLI.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)