### PR TITLE
docs(run-run): clarify shell completion setup for project-local installs

### DIFF
--- a/.changeset/run-run-completion-readme.md
+++ b/.changeset/run-run-completion-readme.md
@@ -1,0 +1,5 @@
+---
+"@vlandoss/run-run": patch
+---
+
+Document shell completion setup for project-local installs (mise/direnv guard + cached-script fallback)

--- a/packages/run-run/README.md
+++ b/packages/run-run/README.md
@@ -35,27 +35,69 @@ See [`CLI.md`](./CLI.md) for the full reference (auto-generated per release).
 
 ## Shell completion
 
-`rr` ships a `completion` subcommand that prints a shell-specific script. Add it to your shell rc file:
+`rr` ships a `completion` subcommand that prints a shell-specific script.
+Pick the option that matches your setup.
+
+### Option A — with `mise` or `direnv` (recommended)
+
+If your tooling puts `node_modules/.bin` on `PATH` per-project, `rr` resolves at shell startup and completion picks up new commands automatically on each new shell. Examples:
+
+```toml
+# mise.toml
+[env]
+_.path = ["{{config_root}}/node_modules/.bin"]
+```
+
+```sh
+# .envrc (direnv)
+PATH_add node_modules/.bin
+```
+
+Then add a guarded eval to your shell rc — the guard makes it a no-op when you open a shell outside any project:
 
 ```sh
 # zsh — ~/.zshrc
-eval "$(rr completion zsh)"
+command -v rr >/dev/null 2>&1 && eval "$(rr completion zsh)"
 
 # bash — ~/.bashrc
-eval "$(rr completion bash)"
+command -v rr >/dev/null 2>&1 && eval "$(rr completion bash)"
 
 # fish — ~/.config/fish/config.fish
-rr completion fish | source
+command -v rr >/dev/null 2>&1; and rr completion fish | source
 ```
 
-**Prerequisite:** the [`usage`](https://usage.jdx.dev) CLI must be on your `PATH` (it powers completion at runtime). Install via one of:
+### Option B — without a per-project PATH manager
+
+Cache the completion script once, then source the cached file from your shell rc. Run the generation step from inside a project that has `@vlandoss/run-run` installed:
+
+```sh
+mkdir -p ~/.cache
+pnpm exec rr completion zsh  > ~/.cache/rr-completion.zsh
+pnpm exec rr completion bash > ~/.cache/rr-completion.bash
+pnpm exec rr completion fish > ~/.cache/rr-completion.fish
+```
+
+```sh
+# zsh — ~/.zshrc
+[ -f ~/.cache/rr-completion.zsh ] && source ~/.cache/rr-completion.zsh
+
+# bash — ~/.bashrc
+[ -f ~/.cache/rr-completion.bash ] && source ~/.cache/rr-completion.bash
+
+# fish — ~/.config/fish/config.fish
+test -f ~/.cache/rr-completion.fish; and source ~/.cache/rr-completion.fish
+```
+
+Regenerate the cache after upgrading `@vlandoss/run-run` to pick up new commands.
+
+### Prerequisite
+
+The [`usage`](https://usage.jdx.dev) CLI must be on your `PATH` (it powers completion at runtime). Install via one of:
 
 ```sh
 mise use -g usage
 brew install usage
 ```
-
-When you upgrade `@vlandoss/run-run`, the next shell session will pick up new commands automatically — no need to re-run anything.
 
 ## Troubleshooting
 

--- a/packages/run-run/README.md
+++ b/packages/run-run/README.md
@@ -18,7 +18,7 @@ CLI toolbox to fullstack common scripts in [Variable Land](https://variable.land
 ## Installation
 
 ```sh
-pnpm add @vlandoss/run-run
+pnpm add -D @vlandoss/run-run
 ```
 
 It adds the `rr` command to your project.
@@ -28,8 +28,10 @@ It adds the `rr` command to your project.
 Run the help command:
 
 ```sh
-rr help
+pnpm rr help
 ```
+
+> If you have `node_modules/.bin` on your `PATH` (e.g. via `mise` or `direnv` — see [Shell completion](#shell-completion)), you can drop the `pnpm` prefix and invoke `rr` directly.
 
 See [`CLI.md`](./CLI.md) for the full reference (auto-generated per release).
 
@@ -104,5 +106,5 @@ brew install usage
 To enable debug mode, set the `DEBUG` environment variable to `run-run:*` before running *any* command.
 
 ```sh
-DEBUG=run-run:* rr <command>
+DEBUG=run-run:* pnpm rr <command>
 ```


### PR DESCRIPTION
## Summary
- `rr` is a project-local dev dep, so the previous `eval "$(rr completion zsh)"` snippet in `~/.zshrc` quietly failed for users without per-project PATH wiring.
- README now documents two paths:
  - **Option A** — `mise` / `direnv` examples + a `command -v` guarded eval (keeps the auto-pickup-on-upgrade property).
  - **Option B** — cache the script once via `pnpm exec rr completion <shell> > ~/.cache/...`, source the cached file from the rc.
- Includes a changeset (patch) so the updated README ships to npm.

## Test plan
- [ ] Open a new shell with `mise`/`direnv` wiring `node_modules/.bin` → completion loads.
- [ ] Open a shell outside any project → guarded eval is a silent no-op.
- [ ] Run the Option B generation step, source the cached file → completion works without PATH wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)