### PR TITLE
feat(vland): show banner at start of init command

### DIFF
--- a/.changeset/init-banner.md
+++ b/.changeset/init-banner.md
@@ -1,0 +1,5 @@
+---
+"@vlandoss/vland": patch
+---
+
+Show the vland banner at the start of the `init` command

--- a/packages/vland/src/program/commands/init.ts
+++ b/packages/vland/src/program/commands/init.ts
@@ -2,7 +2,7 @@ import { Argument, createCommand, Option } from "commander";
 import { runInit } from "#src/actions/init.ts";
 import { TEMPLATES, type TemplateName } from "#src/actions/template.ts";
 import type { Context } from "#src/services/ctx.ts";
-import { TOOL_LABELS } from "../ui.ts";
+import { getBannerText, TOOL_LABELS } from "../ui.ts";
 
 type InitOptions = {
   dir?: string;
@@ -25,6 +25,7 @@ export function createInitCommand(ctx: Context) {
     .addOption(new Option("--no-git", "skip git init"))
     .addOption(new Option("-f, --force", "overwrite existing directory").default(false))
     .action(async (name: string | undefined, options: InitOptions) => {
+      console.log(getBannerText(ctx.binPkg.version));
       await runInit(ctx, {
         name,
         ...options,


### PR DESCRIPTION
## Summary
- Print the vland banner via `getBannerText(ctx.binPkg.version)` when `vland init` runs.

## Test plan
- [ ] Run `vland init` locally and confirm the banner appears before the init prompts.