### PR TITLE
chore: deprecate @vlandoss/biome-config, localproxy, starter

### DIFF
--- a/.changeset/deprecate-packages.md
+++ b/.changeset/deprecate-packages.md
@@ -1,0 +1,13 @@
+---
+"@vlandoss/biome-config": patch
+"@vlandoss/localproxy": patch
+"@vlandoss/starter": patch
+---
+
+Deprecate package — final published version with notice.
+
+- `@vlandoss/biome-config` is superseded by [`@vlandoss/config`](https://github.com/variableland/dx/tree/main/packages/config) (use `@vlandoss/config/biome`).
+- `@vlandoss/localproxy` is superseded by [Portless](https://port1355.dev).
+- `@vlandoss/starter` is superseded by [`@vlandoss/vland`](https://github.com/variableland/dx/tree/main/packages/vland).
+
+Each package's `homepage` is repinned to a tag URL so the deprecation README stays reachable after the source is removed from the monorepo.

--- a/dotfiles/biome-config/package.json
+++ b/dotfiles/biome-config/package.json
@@ -2,7 +2,7 @@
   "name": "@vlandoss/biome-config",
   "version": "0.0.8",
   "description": "Biome configuration file for @variableland",
-  "homepage": "https://github.com/variableland/dx/tree/main/dotfiles/biome-config#readme",
+  "homepage": "https://github.com/variableland/dx/tree/%40vlandoss%2Fbiome-config%400.0.9/dotfiles/biome-config#readme",
   "bugs": {
     "url": "https://github.com/variableland/dx/issues"
   },

--- a/packages/localproxy/README.md
+++ b/packages/localproxy/README.md
@@ -1,5 +1,14 @@
 # 🛠️ localproxy
 
+> [!CAUTION]
+> **Deprecated.** This package is no longer maintained. Use [Portless](https://port1355.dev) instead — it provides the same `*.localhost` mapping with automatic HTTPS and a smoother setup. This package will not receive further updates and will be removed from the registry shortly.
+>
+> ```sh
+> # Migration: install Portless and remove localproxy
+> # See https://port1355.dev for setup
+> pnpm remove -g @vlandoss/localproxy
+> ```
+
 **Simple local development proxy automation with Caddy + hosts management**
 
 Stop remembering ports! localproxy automatically maps your projects to clean `.localhost` domains with automatic HTTPS and hosts file management.

--- a/packages/localproxy/package.json
+++ b/packages/localproxy/package.json
@@ -2,7 +2,7 @@
   "name": "@vlandoss/localproxy",
   "version": "0.2.2",
   "description": "Simple local development proxy automation",
-  "homepage": "https://github.com/variableland/dx/tree/main/packages/localproxy#readme",
+  "homepage": "https://github.com/variableland/dx/tree/%40vlandoss%2Flocalproxy%400.2.3/packages/localproxy#readme",
   "bugs": {
     "url": "https://github.com/variableland/dx/issues"
   },

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -2,7 +2,7 @@
   "name": "@vlandoss/starter",
   "version": "0.4.1",
   "description": "The CLI to init a new project in Variable Land",
-  "homepage": "https://github.com/variableland/dx/tree/main/packages/starter#readme",
+  "homepage": "https://github.com/variableland/dx/tree/%40vlandoss%2Fstarter%400.4.2/packages/starter#readme",
   "bugs": {
     "url": "https://github.com/variableland/dx/issues"
   },


### PR DESCRIPTION
## Summary

Final-pass deprecation for three packages, paving the way to remove their source from the monorepo in a follow-up PR.

- **`@vlandoss/biome-config`** → superseded by [`@vlandoss/config`](https://github.com/variableland/dx/tree/main/packages/config) (use `@vlandoss/config/biome`). Caution note already in README.
- **`@vlandoss/localproxy`** → superseded by [Portless](https://port1355.dev). Caution note added in this PR.
- **`@vlandoss/starter`** → superseded by [`@vlandoss/vland`](https://github.com/variableland/dx/tree/main/packages/vland). Caution note already in README; bumping a patch so the deprecation note ships under the `latest` tag.

Each package's `homepage` is repinned to its **upcoming tag URL** so the deprecation README stays reachable on npm even after the source dirs are removed:

- `@vlandoss/biome-config@0.0.9` → `tree/%40vlandoss%2Fbiome-config%400.0.9/dotfiles/biome-config#readme`
- `@vlandoss/localproxy@0.2.3`   → `tree/%40vlandoss%2Flocalproxy%400.2.3/packages/localproxy#readme`
- `@vlandoss/starter@0.4.2`      → `tree/%40vlandoss%2Fstarter%400.4.2/packages/starter#readme`

## After merge

1. Bot opens "chore: update versions" PR → merge it → CI runs `pnpm changeset publish` → tags `@vlandoss/<pkg>@<ver>` get created → homepage URLs resolve.
2. Run `npm deprecate` × 3:

```sh
npm deprecate @vlandoss/biome-config "*" "Deprecated. Use @vlandoss/config/biome instead. See https://github.com/variableland/dx/tree/%40vlandoss%2Fbiome-config%400.0.9/dotfiles/biome-config#readme"
npm deprecate @vlandoss/localproxy "*" "Deprecated. Use Portless instead: https://port1355.dev. See https://github.com/variableland/dx/tree/%40vlandoss%2Flocalproxy%400.2.3/packages/localproxy#readme"
npm deprecate @vlandoss/starter "*" "Deprecated. Use @vlandoss/vland instead. See https://github.com/variableland/dx/tree/%40vlandoss%2Fstarter%400.4.2/packages/starter#readme"
```

3. A separate PR removes the source for the three packages (already prepared locally on `chore/remove-deprecated-packages`; opens once this lands).

## Test plan

- [ ] Bot opens the Version PR and bumps biome-config 0.0.8 → 0.0.9, localproxy 0.2.2 → 0.2.3, starter 0.4.1 → 0.4.2
- [ ] After Version PR merges, `npm view @vlandoss/<pkg> version` shows the new version under `latest`
- [ ] After publish, `git tag -l '@vlandoss/<pkg>@<ver>'` shows each tag exists
- [ ] Homepage URLs in npm UI resolve to a tagged tree on GitHub showing the caution note
- [ ] After `npm deprecate`, `npm view @vlandoss/<pkg> deprecated` returns the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)