### PR TITLE
fix(run-run): forward flags through tools shims

### DIFF
--- a/.changeset/run-run-tools-passthrough.md
+++ b/.changeset/run-run-tools-passthrough.md
@@ -1,0 +1,9 @@
+---
+"@vlandoss/run-run": patch
+---
+
+Stop swallowing flags passed to the `tools` shims.
+
+`rr` defines `-v/--version`, `-h/--help` and `--usage` at the root level. By default Commander accepts those flags anywhere in the argv, so invocations like `rr tools biome --version` (or the published `biome` shim, which delegates to `rr tools biome "$@"`) were resolved by the root parser and printed rr's own version/help instead of forwarding to the underlying tool.
+
+Enabling `enablePositionalOptions()` on the root program and `passThroughOptions()` on the `tools` command keeps the root flags scoped to the root, so anything after `rr tools <bin>` is forwarded verbatim to the wrapped binary. Same applies to the `oxfmt`, `oxlint` and `tsdown` shims.

--- a/packages/run-run/src/program/commands/tools.ts
+++ b/packages/run-run/src/program/commands/tools.ts
@@ -42,6 +42,7 @@ function createToolCommand(bin: string, shell: ShellService) {
 export function createToolsCommand(ctx: Context) {
   return createCommand("tools")
     .description("expose the internal tools 🛠️")
+    .passThroughOptions()
     .addCommand(createToolCommand("biome", ctx.shell))
     .addCommand(createToolCommand("oxfmt", ctx.shell))
     .addCommand(createToolCommand("oxlint", ctx.shell))

--- a/packages/run-run/src/program/index.ts
+++ b/packages/run-run/src/program/index.ts
@@ -26,6 +26,7 @@ export async function createProgram(options: Options) {
   const program = addUsage(
     createCommand("rr")
       .usage("[options] <command...>")
+      .enablePositionalOptions()
       .version(version, "-v, --version")
       .addHelpText("before", getBannerText(version))
       .addHelpText("after", CREDITS_TEXT)


### PR DESCRIPTION
## Summary
- Root-level flags on `rr` (`-v/--version`, `-h/--help`, `--usage`) were being captured even when passed after a subcommand. So `rr tools biome --version` — and the published `biome` shim that simply wraps `rr tools biome "$@"` — printed rr's own version instead of biome's. Same affected `oxfmt`, `oxlint`, `tsdown` shims.
- Fix on the root program: `.enablePositionalOptions()` so root flags are only recognized **before** a subcommand name.
- Fix on the `tools` subcommand: `.passThroughOptions()` so once the bin name is matched (e.g. `biome`), the remaining args are forwarded untouched.
- Changeset bumps `@vlandoss/run-run` as `patch` — bug fix, no API surface change.

## Test plan
- [x] `pnpm test` in `packages/run-run` — 14/14 integration tests pass
- [x] `pnpm rr tsc` (types pass)
- [x] Manual:
  - `./bin -v` → `0.5.3` (root flag still works)
  - `./bin --usage` → emits KDL (root flag still works)
  - `./bin tools biome --version` → `Version: 2.4.4` (forwarded — was `0.5.3` before)
  - `./bin tools biome --help` → biome's help (was rr's help before)
  - `./bin tools biome --usage` → biome rejects flag (was emitting rr's KDL before)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)