### PR TITLE
docs(cli): refresh README for the microkernel model

### DIFF
--- a/.changeset/cli-readme-toolbox.md
+++ b/.changeset/cli-readme-toolbox.md
@@ -1,0 +1,7 @@
+---
+"@rrlab/cli": patch
+---
+
+Refresh the README for the microkernel model.
+
+Drop the stale, hand-maintained `Toolbox` section (it still listed `rimraf`, which isn't a plugin) and fold the tool list into the `Plugins` section as the single source of truth. The official plugins are now named there — `biome`, `oxc`, `ts`, `tsdown` — each linked to the tool it wraps, framed as capabilities added via plugins rather than a flat bag of tools.

--- a/run-run/cli/README.md
+++ b/run-run/cli/README.md
@@ -6,15 +6,6 @@ CLI toolbox to fullstack common scripts in [Variable Land](https://variable.land
 
 - Node.js >= 20.0.0
 
-## Toolbox
-
-- [biome](https://biomejs.dev)
-- [tsc](https://www.typescriptlang.org)
-- [rimraf](https://www.npmjs.com/package/rimraf)
-- [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html)
-- [oxlint](https://oxc.rs/docs/guide/usage/linter.html)
-- [tsdown](https://tsdown.dev)
-
 ## Installation
 
 ```sh
@@ -37,7 +28,7 @@ See [`CLI.md`](./CLI.md) for the full reference (auto-generated per release).
 
 ## Plugins
 
-`rr` is a microkernel: every tool (Biome, TypeScript, tsdown, …) lives in its own `@rrlab/<tool>-plugin` package. Install one with:
+`rr` is a microkernel: every tool lives in its own `@rrlab/<tool>-plugin` package. The official plugins are `biome` ([Biome](https://biomejs.dev)), `oxc` ([oxlint](https://oxc.rs/docs/guide/usage/linter.html) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html)), `ts` ([tsc](https://www.typescriptlang.org)) and `tsdown` ([tsdown](https://tsdown.dev)). Install one with:
 
 ```sh
 rr plugins add biome

--- a/run-run/cli/README.md
+++ b/run-run/cli/README.md
@@ -28,7 +28,16 @@ See [`CLI.md`](./CLI.md) for the full reference (auto-generated per release).
 
 ## Plugins
 
-`rr` is a microkernel: every tool lives in its own `@rrlab/<tool>-plugin` package. The official plugins are `biome` ([Biome](https://biomejs.dev)), `oxc` ([oxlint](https://oxc.rs/docs/guide/usage/linter.html) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html)), `ts` ([tsc](https://www.typescriptlang.org)) and `tsdown` ([tsdown](https://tsdown.dev)). Install one with:
+`rr` is a microkernel: every tool lives in its own `@rrlab/<tool>-plugin` package. The official plugins are:
+
+| Plugin   | Wraps                                                                                                          | Install                  |
+| -------- | -------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `biome`  | [Biome](https://biomejs.dev)                                                                                   | `rr plugins add biome`   |
+| `oxc`    | [oxlint](https://oxc.rs/docs/guide/usage/linter.html) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) | `rr plugins add oxc`     |
+| `ts`     | [tsc](https://www.typescriptlang.org)                                                                          | `rr plugins add ts`      |
+| `tsdown` | [tsdown](https://tsdown.dev)                                                                                   | `rr plugins add tsdown`  |
+
+Install one with:
 
 ```sh
 rr plugins add biome


### PR DESCRIPTION
## What

Refreshes `run-run/cli/README.md` to match the microkernel model the rest of the README already describes.

- **Drops the `Toolbox` section.** It was a hand-maintained flat list of tool homepages that had already drifted — it still listed `rimraf`, which isn't a plugin, and split `oxc` into two entries (`oxlint`/`oxfmt`) while omitting the plugin that owns them.
- **Folds the tool list into the existing `Plugins` section** as the single source of truth. The official plugins are now named inline — `biome` (Biome), `oxc` (oxlint + oxfmt), `ts` (tsc), `tsdown` (tsdown) — each linked to the tool it wraps.

## Why

Since the microkernel refactor, every tool lives in its own `@rrlab/<tool>-plugin`. A separate static `Toolbox` list duplicated info the plugin packages already own and drifted out of sync. Enumerating by *plugin* (the unit you actually `rr plugins add`) instead of by loose tool keeps it accurate and aligns with the kernel's tool-agnostic framing.

## Notes

- Docs-only; the `CLI toolbox to fullstack common scripts` tagline is left untouched.
- Includes a `patch` changeset for `@rrlab/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)