### PR TITLE
refactor: standardize typecheck task as tscheck

### DIFF
--- a/lefthook/turborepo.yml
+++ b/lefthook/turborepo.yml
@@ -6,7 +6,7 @@ pre-commit:
       stage_fixed: true
 
     - name: tscheck
-      run: pnpm turbo run test:types --filter='...[HEAD]'
+      run: pnpm turbo run tscheck --filter='...[HEAD]'
       glob:
         - "*.{ts,tsx}"
         - "tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",
-    "test:types": "turbo test:types",
+    "tscheck": "turbo tscheck",
     "test:unit": "turbo test:unit",
     "test:integration": "turbo test:integration"
   },

--- a/run-run/CLAUDE.md
+++ b/run-run/CLAUDE.md
@@ -8,7 +8,7 @@ Orientation for working on the `@rrlab/*` packages. Prerequisite reading: the re
 
 This means:
 
-- **Do not wrap `rr` in `package.json` scripts.** Aliases like `"lint": "rr lint"`, `"format": "rr format --fix"`, `"test:types": "rr tsc"`, `"check": "rr check"` re-introduce the very indirection rr was created to remove (`pnpm lint` → `rr lint` → `biome check` is three layers for what should be one). The user types `rr lint`, not `pnpm lint`.
+- **Do not wrap `rr` in `package.json` scripts.** Aliases like `"lint": "rr lint"`, `"format": "rr format --fix"`, `"tscheck": "rr tsc"`, `"check": "rr check"` re-introduce the very indirection rr was created to remove (`pnpm lint` → `rr lint` → `biome check` is three layers for what should be one). The user types `rr lint`, not `pnpm lint`.
 - **The expected setup**: `node_modules/.bin` on `PATH` — typically via mise (`[env] _.path = ["{{config_root}}/node_modules/.bin"]`) — so `rr` is directly invokable from the project root without a package-manager hop. Templates ship a `mise.toml` that wires this for new projects.
 - **`package.json scripts` may still exist** — but only for things `rr` does NOT cover (`vitest run`, `tsx watch`, `node dist/...`, `vite dev`, `turbo run dev`, `changeset publish`). These are not single-command aliases; they're either different tools or multi-step compositions.
 - **Lifecycle / orchestration hooks MAY call `rr` directly.** lefthook git hooks, `prepublishOnly`, GitHub Actions workflows — those are triggered by other systems, not typed by the developer, so they don't fight the "one entry point" goal. A `pre-commit: rr jsc --fix-staged` lefthook job is exactly right.

--- a/run-run/cli/package.json
+++ b/run-run/cli/package.json
@@ -56,7 +56,7 @@
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
     "prepublishOnly": "pnpm build",
-    "test:types": "rr tsc"
+    "tscheck": "rr tsc"
   },
   "dependencies": {
     "@clack/prompts": "0.11.0",

--- a/shared/clibuddy/package.json
+++ b/shared/clibuddy/package.json
@@ -27,7 +27,7 @@
     "build": "tsdown",
     "prepublishOnly": "pnpm build",
     "test": "vitest run",
-    "test:types": "rr tsc"
+    "tscheck": "rr tsc"
   },
   "dependencies": {
     "@pnpm/fs.find-packages": "1000.0.24",

--- a/shared/loggy/package.json
+++ b/shared/loggy/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsdown",
     "prepublishOnly": "pnpm build",
-    "test:types": "rr tsc"
+    "tscheck": "rr tsc"
   },
   "publishConfig": {
     "access": "public",

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
     "test": {
       "dependsOn": ["build"]
     },
-    "test:types": {},
+    "tscheck": {},
     "test:unit": {},
     "test:integration": {
       "dependsOn": ["build"]

--- a/vland/cli/package.json
+++ b/vland/cli/package.json
@@ -36,7 +36,7 @@
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
-    "test:types": "rr tsc"
+    "tscheck": "rr tsc"
   },
   "dependencies": {
     "@clack/prompts": "0.11.0",

--- a/vland/cli/test/integration/init-templates.test.ts
+++ b/vland/cli/test/integration/init-templates.test.ts
@@ -78,7 +78,7 @@ describe("vland init (template scaffolding)", () => {
     const scriptNames = Object.keys(pkg.scripts ?? {});
     expect(scriptNames).not.toContain("lint");
     expect(scriptNames).not.toContain("lint:fix");
-    expect(scriptNames).not.toContain("test:types");
+    expect(scriptNames).not.toContain("tscheck");
     expect(scriptNames).not.toContain("check");
     expect(scriptNames).not.toContain("build");
   });


### PR DESCRIPTION
## What

Rename the typecheck task/script from `test:types` to `tscheck` across the workspace, and update the shared lefthook pre-commit job to run `turbo run tscheck`.

## Why

The shared lefthook config (`lefthook/turborepo.yml`, consumed via `extends`/remotes) ran `turbo run test:types`. Consumers that name their turbo task `tscheck` (e.g. yoppy, and all of `apps/*` + `packages/*` there) hit `Could not find task 'test:types'`, which blocked their pre-commit. Standardizing on `tscheck` aligns the shared hook with the consumer convention.

## Changes

- `turbo.json`: `test:types` task → `tscheck`
- root `package.json` + `shared/loggy`, `shared/clibuddy`, `vland/cli`, `run-run/cli` scripts: `test:types` → `tscheck`
- `lefthook/turborepo.yml`: pre-commit job → `pnpm turbo run tscheck`
- `vland/cli` init-templates test guard and `run-run/CLAUDE.md` example updated to the new name

## Verification

`turbo run tscheck` resolves; this branch's own pre-commit ran green (`jscheck` + `tscheck`). CHANGELOG history left untouched.

## Heads-up

This makes `tscheck` the standard. Any other repo that extends this lefthook config **and** still names its turbo task `test:types` will need to rename to `tscheck` (or it will fail pre-commit). Consumers already on `tscheck` (e.g. yoppy) start working once this lands on `main` and they re-run `lefthook install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)